### PR TITLE
Update Adafruit_LIS3DH.cpp for correct 16g divider

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -156,7 +156,7 @@ void Adafruit_LIS3DH::read(void) {
   #endif
   uint8_t range = getRange();
   uint16_t divider = 1;
-  if (range == LIS3DH_RANGE_16_G) divider = 2048;
+  if (range == LIS3DH_RANGE_16_G) divider = 1365; // different sensitivity at 16g
   if (range == LIS3DH_RANGE_8_G) divider = 4096;
   if (range == LIS3DH_RANGE_4_G) divider = 8190;
   if (range == LIS3DH_RANGE_2_G) divider = 16380;


### PR DESCRIPTION
Changed divider from 2048 to 1365 for conversion. This reflects the different relative sensitivity documented in the data sheet. The previous code reads lower than the correct value by a factor of 8 mg/bit (assumed) / 12 mg bit (documented).
