### PR TITLE
Add ACT registers.

### DIFF
--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -71,6 +71,8 @@
 #define LIS3DH_REG_TIMELIMIT     0x3B
 #define LIS3DH_REG_TIMELATENCY   0x3C
 #define LIS3DH_REG_TIMEWINDOW    0x3D
+#define LIS3DH_REG_ACTTHS        0x3E
+#define LIS3DH_REG_ACTDUR        0x3F
 
 typedef enum
 {


### PR DESCRIPTION
This change adds the addresses for the ACT registers.  This used for setting the "sleep-to-wake" and "return-to-sleep" functionality of this sensor.

Since it is only adding two #defines, there are no consequences or limitations for this change.  It is fully compatible with existing code and integrations with this library.