### PR TITLE
Update getEvent to match new bool return value

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -320,6 +320,8 @@ bool Adafruit_LIS3DH::getEvent(sensors_event_t *event) {
   event->acceleration.x = x_g * SENSORS_GRAVITY_STANDARD;
   event->acceleration.y = y_g * SENSORS_GRAVITY_STANDARD;
   event->acceleration.z = z_g * SENSORS_GRAVITY_STANDARD;
+    
+  return true;
 }
 
 /**************************************************************************/


### PR DESCRIPTION
Return statement was missing from bool Adafruit_LIS3DH::getEvent(sensors_event_t *event).
Pattern matching with the ALDX345 library, the Adafruit_Sensor API was changed at some point,
and the proper value for the LIS3DH sensor is to return true.

I discovered the bug based on a warning from clang.