### PR TITLE
Add isAlive() to check LIS3DH connection

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -131,6 +131,25 @@ bool Adafruit_LIS3DH::begin(uint8_t i2caddr) {
   return true;
 }
 
+/**************************************************************************/
+
+/*!
+    @brief  Checks connection status to LIS3DH.
+*/
+
+/**************************************************************************/
+
+bool Adafruit_LIS3DH::isAlive(void) {
+
+  uint8_t deviceid = readRegister8(LIS3DH_REG_WHOAMI);
+  if (deviceid != 0x33)
+  {
+    /* No LIS3DH detected ... return false */
+    //Serial.println(deviceid, HEX);
+    return false;
+  }
+  return true;
+}
 
 void Adafruit_LIS3DH::read(void) {
   // read x y z at once

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -81,6 +81,7 @@
 typedef enum
 {
   LIS3DH_RANGE_16_G         = 0b11,   // +/- 16g
+
   LIS3DH_RANGE_8_G           = 0b10,   // +/- 8g
   LIS3DH_RANGE_4_G           = 0b01,   // +/- 4g
   LIS3DH_RANGE_2_G           = 0b00    // +/- 2g (default value)
@@ -118,6 +119,7 @@ class Adafruit_LIS3DH : public Adafruit_Sensor {
   Adafruit_LIS3DH(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
   
   bool       begin(uint8_t addr = LIS3DH_DEFAULT_ADDRESS);
+  bool       isAlive(void);
  
   void read();
   int16_t readADC(uint8_t a);


### PR DESCRIPTION
I needed to check the connection status to the LIS3DH without reading data. I just pulled this code down from the `begin()` function where it checks the connection. 

I've run and tested the `isAlive()` function on an Adafruit HUZZAH ESP8266. No other platforms have been tested. Can't imagine it will be a problem on any other platform though, since the code is exactly the same that was already in `begin()`.

I did not update any of the examples to reflect usage, but I would be more than happy to.
