### PR TITLE
[Feature] add simple FIFO capabilities

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -175,7 +175,7 @@ bool Adafruit_LIS3DH::haveNewData(void) {
   if (fifoEnabled && !zyx_available) {
     // Check the FIFO_SRC_REG if it's empty
      Adafruit_BusIO_Register fifosrc = Adafruit_BusIO_Register(
-      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_FIFOSRC, 1);
+         i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_FIFOSRC, 1);
     Adafruit_BusIO_RegisterBits fifo_empty =
         Adafruit_BusIO_RegisterBits(&fifosrc, 1, 5);
     return !fifo_empty.read();
@@ -357,7 +357,8 @@ void Adafruit_LIS3DH::setFifoMode(lis3dh_fifoMode_t mode) {
   // Any mode that isn't bypass needs this turned on
   bool enabled = (mode != LIS3DH_FIFO_BYPASS);
   // Check if we need to write it
-  if (fifoEnabled != enabled) fifo_bit.write(enabled);
+  if (fifoEnabled != enabled) 
+    fifo_bit.write(enabled);
   // Update our internal var if we've turned on the fifo
   fifoEnabled = enabled;
 }

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -174,8 +174,8 @@ bool Adafruit_LIS3DH::haveNewData(void) {
   // Check the fifo if we are enabled
   if (fifoEnabled && !zyx_available) {
     // Check the FIFO_SRC_REG if it's empty
-     Adafruit_BusIO_Register fifosrc = Adafruit_BusIO_Register(
-         i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_FIFOSRC, 1);
+    Adafruit_BusIO_Register fifosrc = Adafruit_BusIO_Register(
+        i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_FIFOSRC, 1);
     Adafruit_BusIO_RegisterBits fifo_empty =
         Adafruit_BusIO_RegisterBits(&fifosrc, 1, 5);
     return !fifo_empty.read();
@@ -357,7 +357,7 @@ void Adafruit_LIS3DH::setFifoMode(lis3dh_fifoMode_t mode) {
   // Any mode that isn't bypass needs this turned on
   bool enabled = (mode != LIS3DH_FIFO_BYPASS);
   // Check if we need to write it
-  if (fifoEnabled != enabled) 
+  if (fifoEnabled != enabled)
     fifo_bit.write(enabled);
   // Update our internal var if we've turned on the fifo
   fifoEnabled = enabled;

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -20,6 +20,7 @@
  *  from Adafruit!
  *
  *  K. Townsend / Limor Fried (Ladyada) - (Adafruit Industries).
+ *  Matthew Carlson
  *
  *  BSD license, all text above must be included in any redistribution
  */
@@ -195,7 +196,9 @@
  *   TR       Trigger selection. Default value: 0
  *            0: Trigger event liked to trigger signal on INT1
  *            1: Trigger event liked to trigger signal on INT2
- *   FTH4:0   Default value: 0
+ *   FTH4-FTH0  
+ *           On Read: The number of items in the fifo, default value 0000
+ *           On Write: The highwater mark for the fifo
  */
 #define LIS3DH_REG_FIFOCTRL 0x2E
 #define LIS3DH_REG_FIFOSRC                                                     \
@@ -339,6 +342,14 @@ typedef enum {
 
 } lis3dh_dataRate_t;
 
+/** Used with register 0x2E (LIS3DH_REG_FIFOCTRL) to set fifo mode **/
+typedef enum {
+  LIS3DH_FIFO_BYPASS = 0b00,    //  Disabled
+  LIS3DH_FIFO_MODE = 0b01,      //  The default mode
+  LIS3DH_FIFO_STREAM = 0b10,    //  Stream mode
+  LIS3DH_FIFO_STREAM_TO = 0b11, //  stream to FIFO mode
+} lis3dh_fifoMode_t;
+
 /*!
  *  @brief  Class that stores state and functions for interacting with
  *          Adafruit_LIS3DH
@@ -370,6 +381,8 @@ public:
                 uint8_t timelatency = 20, uint8_t timewindow = 255);
   uint8_t getClick(void);
 
+  void setFifoMode(lis3dh_fifoMode_t mode = LIS3DH_FIFO_BYPASS);
+
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */
   int16_t z; /**< z axis value */
@@ -392,6 +405,8 @@ private:
   int8_t _i2caddr;
 
   int32_t _sensorID;
+
+  boolean fifoEnabled = false; // by default, we are non-fifo mode
 };
 
 #endif

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -196,7 +196,7 @@
  *   TR       Trigger selection. Default value: 0
  *            0: Trigger event liked to trigger signal on INT1
  *            1: Trigger event liked to trigger signal on INT2
- *   FTH4-FTH0  
+ *   FTH4-FTH0
  *           On Read: The number of items in the fifo, default value 0000
  *           On Write: The highwater mark for the fifo
  */

--- a/examples/fifodemo/fifodemo.ino
+++ b/examples/fifodemo/fifodemo.ino
@@ -69,8 +69,7 @@ void loop() {
   // The Fifo can hold 32 samples at once
   int samples_collected = 0;
   for (samples_collected=0; samples_collected < 32 && lis.haveNewData(); samples_collected++) {
-    lis.getEvent(&data[i]);
-    samples_collected = i;
+    lis.getEvent(&data[samples_collected]);
   }
   // We should have 32 samples
   // Process them here

--- a/examples/fifodemo/fifodemo.ino
+++ b/examples/fifodemo/fifodemo.ino
@@ -1,0 +1,81 @@
+
+// Basic demo for accelerometer readings via fifo from Adafruit LIS3DH
+
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_LIS3DH.h>
+#include <Adafruit_Sensor.h>
+
+// Used for software SPI
+#define LIS3DH_CLK 13
+#define LIS3DH_MISO 12
+#define LIS3DH_MOSI 11
+// Used for hardware & software SPI
+#define LIS3DH_CS 10
+
+// software SPI
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, LIS3DH_MOSI, LIS3DH_MISO, LIS3DH_CLK);
+// hardware SPI
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS);
+// I2C
+Adafruit_LIS3DH lis = Adafruit_LIS3DH();
+
+void setup(void) {
+  Serial.begin(115200);
+  while (!Serial) delay(10);     // will pause Zero, Leonardo, etc until serial console opens
+
+  Serial.println("LIS3DH test!");
+
+  if (! lis.begin(0x18)) {   // change this to 0x19 for alternative i2c address
+    Serial.println("Couldnt start");
+    while (1) yield();
+  }
+  Serial.println("LIS3DH found!");
+
+  lis.setRange(LIS3DH_RANGE_4_G);   // 2, 4, 8 or 16 G!
+
+  Serial.print("Range = "); Serial.print(2 << lis.getRange());
+  Serial.println("G");
+
+  // First set the fifo to bypass mode to clear the FIFO
+  // This important because the hardware might not have been reset if we warm flashed
+  imu.setFifoMode(LIS3DH_FIFO_BYPASS);
+
+  lis.setDataRate(LIS3DH_DATARATE_100_HZ);
+  Serial.print("Data rate set to: ");
+  switch (lis.getDataRate()) {
+    case LIS3DH_DATARATE_1_HZ: Serial.println("1 Hz"); break;
+    case LIS3DH_DATARATE_10_HZ: Serial.println("10 Hz"); break;
+    case LIS3DH_DATARATE_25_HZ: Serial.println("25 Hz"); break;
+    case LIS3DH_DATARATE_50_HZ: Serial.println("50 Hz"); break;
+    case LIS3DH_DATARATE_100_HZ: Serial.println("100 Hz"); break;
+    case LIS3DH_DATARATE_200_HZ: Serial.println("200 Hz"); break;
+    case LIS3DH_DATARATE_400_HZ: Serial.println("400 Hz"); break;
+
+    case LIS3DH_DATARATE_POWERDOWN: Serial.println("Powered Down"); break;
+    case LIS3DH_DATARATE_LOWPOWER_5KHZ: Serial.println("5 Khz Low Power"); break;
+    case LIS3DH_DATARATE_LOWPOWER_1K6HZ: Serial.println("16 Khz Low Power"); break;
+  }
+  // enable the fifo and set the right mode
+  imu.setFifoMode(LIS3DH_FIFO_MODE); // writes will stop once the fifo is full
+  //imu.setFifoMode(LIS3DH_FIFO_STREAM); // stream mode will overrwrite fifo values once full
+  //imu.setFifoMode(LIS3DH_FIFO_STREAM_TO); // will be in stream mode until an interrupt comes in
+}
+// A place to store our samples
+sensors_event_t data[32]; 
+void loop() {
+  
+  // We are going to get all the data at once
+  // The Fifo can hold 32 samples at once
+  int samples_collected = 0;
+  for (samples_collected=0; samples_collected < 32 && lis.haveNewData(); samples_collected++) {
+    lis.getEvent(&data[i]);
+    samples_collected = i;
+  }
+  // We should have 32 samples
+  // Process them here
+
+  // We can just wait for a second for the fifo to queue more samples
+  // We get 100 samples a second and it can hold 32 samples
+  delay(900/(100/32)); // 0.9 seconds / 100 samples / 32 samples in queue = ms to wait until fifo is full
+}

--- a/examples/fifodemo/fifodemo.ino
+++ b/examples/fifodemo/fifodemo.ino
@@ -39,7 +39,7 @@ void setup(void) {
 
   // First set the fifo to bypass mode to clear the FIFO
   // This important because the hardware might not have been reset if we warm flashed
-  imu.setFifoMode(LIS3DH_FIFO_BYPASS);
+  lis.setFifoMode(LIS3DH_FIFO_BYPASS);
 
   lis.setDataRate(LIS3DH_DATARATE_100_HZ);
   Serial.print("Data rate set to: ");
@@ -57,9 +57,9 @@ void setup(void) {
     case LIS3DH_DATARATE_LOWPOWER_1K6HZ: Serial.println("16 Khz Low Power"); break;
   }
   // enable the fifo and set the right mode
-  imu.setFifoMode(LIS3DH_FIFO_MODE); // writes will stop once the fifo is full
-  //imu.setFifoMode(LIS3DH_FIFO_STREAM); // stream mode will overrwrite fifo values once full
-  //imu.setFifoMode(LIS3DH_FIFO_STREAM_TO); // will be in stream mode until an interrupt comes in
+  lis.setFifoMode(LIS3DH_FIFO_MODE); // writes will stop once the fifo is full
+  //lis.setFifoMode(LIS3DH_FIFO_STREAM); // stream mode will overrwrite fifo values once full
+  //lis.setFifoMode(LIS3DH_FIFO_STREAM_TO); // will be in stream mode until an interrupt comes in
 }
 // A place to store our samples
 sensors_event_t data[32]; 


### PR DESCRIPTION
This adds rudimentary FIFO capabilities to this library. Namely, turning it off and on, toggling the different modes, and checking if there is data in the fifo.

There's a new example that shows how to use this particular library. I've only tested it with I2C but based on my understanding, SPI shouldn't apply here since we aren't doing burst writes or reads.

Fixes #29 