### PR TITLE
fixing scaling calc from issue #34

### DIFF
--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -309,6 +309,10 @@
  */
 #define LIS3DH_REG_TIMEWINDOW 0x3D
 
+#define LIS3DH_LSB16_TO_KILO_LSB10                                             \
+  64000 ///< Scalar to convert from 16-bit lsb to 10-bit and divide by 1k to
+        ///< convert from milli-gs to gs
+
 /** A structure to represent scales **/
 typedef enum {
   LIS3DH_RANGE_16_G = 0b11, // +/- 16g


### PR DESCRIPTION
This patch re-jiggers the scaling math to properly match the datasheet, as well as giving a clearer explanation of the operations involved.

Fixes the bug reported by @raziel2k in issue #34