### PR TITLE
Temperature measurement

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -467,17 +467,15 @@ void Adafruit_LIS3DH::getSensor(sensor_t *sensor) {
  * @return true: success false: failure
  */
 bool Adafruit_LIS3DH::enableTemperature(bool enable_temp) {
-    Adafruit_BusIO_Register _tmp_cfg = Adafruit_BusIO_Register(
+  Adafruit_BusIO_Register _tmp_cfg = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_TEMPCFG, 1);
   Adafruit_BusIO_RegisterBits _tmp_enable =
       Adafruit_BusIO_RegisterBits(&_tmp_cfg, 1, 6);
-  
-  if(_tmp_enable.write(enable_temp))
-  {
+
+  if (_tmp_enable.write(enable_temp)) {
     _temp_ADC3_en = enable_temp;
     return true;
-  }
-  else
+  } else
     return false;
 }
 
@@ -488,12 +486,11 @@ bool Adafruit_LIS3DH::enableTemperature(bool enable_temp) {
  *  @return temperature in °C
  */
 int8_t Adafruit_LIS3DH::readTemperature(int8_t reference) {
-  if(!_temp_ADC3_en){
-    if(!enableTemperature(true))
+  if (!_temp_ADC3_en) {
+    if (!enableTemperature(true))
       return 0;
   }
 
-// ADC3_H is the delta_t of an unspecified temperature
+  // ADC3_H is the delta_t of an unspecified temperature
   return (int8_t)(readADC(3) >> 8) + reference;
-
 }

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -400,7 +400,7 @@ private:
   int8_t _i2caddr;
 
   int32_t _sensorID;
-  
+
   bool _temp_ADC3_en;
 };
 

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -375,6 +375,9 @@ public:
                 uint8_t timelatency = 20, uint8_t timewindow = 255);
   uint8_t getClick(void);
 
+  bool enableTemperature(bool enable_temp);
+  int8_t readTemperature(int8_t reference);
+
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */
   int16_t z; /**< z axis value */
@@ -397,6 +400,8 @@ private:
   int8_t _i2caddr;
 
   int32_t _sensorID;
+  
+  bool _temp_ADC3_en;
 };
 
 #endif

--- a/examples/tempdemo/tempdemo.ino
+++ b/examples/tempdemo/tempdemo.ino
@@ -1,0 +1,52 @@
+// Basic demo for temperature readings from Adafruit LIS3DH
+
+#include <Wire.h>
+#include <SPI.h>
+#include <Adafruit_LIS3DH.h>
+#include <Adafruit_Sensor.h>
+
+// Used for software SPI
+#define LIS3DH_CLK 13
+#define LIS3DH_MISO 12
+#define LIS3DH_MOSI 11
+// Used for hardware & software SPI
+#define LIS3DH_CS 10
+
+// software SPI
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, LIS3DH_MOSI, LIS3DH_MISO, LIS3DH_CLK);
+// hardware SPI
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS);
+// I2C
+Adafruit_LIS3DH lis = Adafruit_LIS3DH();
+
+void setup(void) {
+#ifndef ESP8266
+  while (!Serial) yield();     // will pause Zero, Leonardo, etc until serial console opens
+#endif
+
+  Serial.begin(9600);
+    Serial.println("Adafruit LIS3DH ADC Test!");
+  
+  if (! lis.begin(0x18)) {   // change this to 0x19 for alternative i2c address
+    Serial.println("Couldnt start");
+    while (1) yield();
+  }
+  Serial.println("LIS3DH found!");
+  
+  lis.setRange(LIS3DH_RANGE_2_G);   // 2, 4, 8 or 16 G!
+  
+  Serial.print("Range = "); Serial.print(2 << lis.getRange());  
+  Serial.println("G");
+}
+
+
+void loop() {
+
+  // LIS3DH measures a Delta T with respect to an unspecified temperature
+  // Pass your best guess of the reference temperature as argument.
+  int8_t temp = lis.readTemperature(13);
+  Serial.print("Temp: "); Serial.print(temp);  Serial.print(" °C");
+
+  Serial.println();
+  delay(200);
+}


### PR DESCRIPTION
Hello Adafruit Community, I added a couple of functions to enable the temperature measurement baked in the ADC3 of the LIS3DH with an example on how to use them.

 bool enableTemperature(bool enable_temp); connects or disconnects the temperature sensor to the ADC3 channel.

  int8_t readTemperature(int8_t reference); checks first whether the temperature measurement is enabled, and if it is, returns a temperature in °C. 
A known limitation of the LIS3DH is the lack of an _absolute_ temperature measurement, in fact the datasheet specifies that the internal temperature is a delta T with respect to an unknown reference. This is the reason a reference temperature is needed as parameter, 13°C was just my best guess.

Kind regards,
Giulio
