### PR TITLE
Add clearInterrupt() function

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -337,7 +337,7 @@ uint8_t Adafruit_LIS3DH::getClick(void) {
  *   @brief  Get uint8_t for INT1 source and clear interrupt
  *   @return register LIS3DH_REG_INT1SRC
  */
-uint8_t Adafruit_LIS3DH::clearInterrupt(void) {
+uint8_t Adafruit_LIS3DH::readAndClearInterrupt(void) {
   Adafruit_BusIO_Register int_reg = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_INT1SRC, 1);
 

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -333,6 +333,17 @@ uint8_t Adafruit_LIS3DH::getClick(void) {
   return click_reg.read();
 }
 
+/*!
+ *   @brief  Get uint8_t for INT1 source and clear interrupt
+ *   @return register LIS3DH_REG_INT1SRC
+ */
+uint8_t Adafruit_LIS3DH::clearInterrupt(void) {
+  Adafruit_BusIO_Register int_reg = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_INT1SRC, 1);
+
+  return int_reg.read();
+}
+
 /**
  * @brief Enable or disable the Data Ready interupt
  *

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -375,7 +375,7 @@ public:
                 uint8_t timelatency = 20, uint8_t timewindow = 255);
   uint8_t getClick(void);
 
-  uint8_t clearInterrupt(void);
+  uint8_t readAndClearInterrupt(void);
 
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -375,6 +375,8 @@ public:
                 uint8_t timelatency = 20, uint8_t timewindow = 255);
   uint8_t getClick(void);
 
+  uint8_t clearInterrupt(void);
+
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */
   int16_t z; /**< z axis value */


### PR DESCRIPTION
Add a function to get and clear interrupt source register in case the LIS3DH is used in interrupt mode.

Works OK with an I2C device, attached to an ESP32, configured to detect click:
```cpp
void sensors_setup() {
    for (uint8_t address = 0x18; address <= 0x19; ++address) {
        if (lis3dh.begin(address)) {
            Serial.print("LIS3DH found at 0x");
            Serial.println(address, HEX);
            break;
        }
    }
    lis3dh.enableDRDY(false);
    lis3dh.setRange(LIS3DH_RANGE_2_G);
    lis3dh.setClick(1, 80);
}

void IRAM_ATTR isr_click() {
    ets_printf("click (LIS3DH) ISR\n");
    worker.click = CLICK_ON;
}

void isr_setup() {
    // Click
    pinMode(GPIO_NUM_33, INPUT);
    attachInterrupt(GPIO_NUM_33, &isr_click, RISING);
}

void task_loop() {
    switch (worker.click) {
    case CLICK_ON:
        uint8_t source = lis3dh.readAndClearInterrupt();
        Serial.print("Interrupt source (0x");
        Serial.print(source, HEX);
        Serial.println(")");
        uint8_t click = lis3dh.getClick();
        Serial.print("Click detected (0x");
        Serial.print(click, HEX);
        Serial.print("): ");
        if (click & 0x30) {
            if (click & 0x10) Serial.print(" single click");
            if (click & 0x20) Serial.print(" double click");
        }
        Serial.println();
        worker.click = CLICK_IDLE;
        break;
    }
}
```