### PR TITLE
Remove unused register

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -117,9 +117,6 @@ bool Adafruit_LIS3DH::begin(uint8_t i2caddr, uint8_t nWAI) {
     }
   }
 
-  Adafruit_BusIO_Register _chip_id = Adafruit_BusIO_Register(
-      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_WHOAMI, 1);
-
   /* Check connection */
   if (getDeviceID() != _wai) {
     /* No LIS3DH detected ... return false */


### PR DESCRIPTION
Removes an unused register variable that was causing ESP32 CI runs to fail:
```
   /home/runner/Arduino/libraries/Adafruit_LIS3DH/Adafruit_LIS3DH.cpp: In member function 'bool Adafruit_LIS3DH::begin(uint8_t, uint8_t)':
  /home/runner/Arduino/libraries/Adafruit_LIS3DH/Adafruit_LIS3DH.cpp:120:27: error: variable '_chip_id' set but not used [-Werror=unused-but-set-variable]
     Adafruit_BusIO_Register _chip_id = Adafruit_BusIO_Register(
                             ^~~~~~~~
  cc1plus: some warnings being treated as errors
```