### PR TITLE
Add Low Power / Normal / High Resolution modes, along with frequency constructor argument

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -388,14 +388,8 @@ bool Adafruit_LIS3DH::enableDRDY(bool enable_drdy, uint8_t int_pin) {
 /*!
  *   @brief  Sets the performance mode for the LIS3DH.
  *
- *   The turn-on time to transition to another operating mode is calculated as:
- *   || 12-bit mode (high resolution) to 8-bit mode (low power): 1/ODR
- *   || 12-bit mode (high resolution) to 10-bit mode (normal): 1/ODR
- *   || 10-bit mode (normal) to 8-bit mode (low power): 1/ODR
- *   || 10-bit mode (normal) to 12-bit mode (high resolution): 7/ODR
- *   || 8-bit mode (low power) to 10-bit mode (normal): 1/ODR
- *   || 8-bit mode (low power) to 12-bit mode (high resolution): 7/ODR
- *   (Where ODR is the Output Data Rate - see lis3dh_dataRate_t for values)
+ *   The turn-on time to transition to 12-bit mode (high resolution) is set at 7ms,
+ *   or swtch to 10-bit mode (normal) or to 8-bit mode (low power) is 1ms
  *
  *   @param  mode
  *          mode - low power, normal, high resolution e.g. LIS3DH_MODE_LOW_POWER
@@ -416,19 +410,19 @@ void Adafruit_LIS3DH::setPerformanceMode(lis3dh_mode_t mode) {
     // set HR bit low (CTRL4) and LP bit high (CTRL1)
     ctrl4_mode_bits.write(0);
     ctrl1_mode_bits.write(1);
-    delay(1); // turn-on transition time (worse case)
+    delay(1); // turn-on transition time (worst case)
     break;
   case LIS3DH_MODE_NORMAL:
     // set HR bit low (CTRL4) and LP bit low (CTRL1)
     ctrl1_mode_bits.write(0);
     ctrl4_mode_bits.write(0);
-    delay(1); // turn-on transition time (worse case)
+    delay(1); // turn-on transition time (worst case)
     break;
   case LIS3DH_MODE_HIGH_RESOLUTION:
     // set HR bit high (CTRL4) and LP bit low (CTRL1)
     ctrl1_mode_bits.write(0);
     ctrl4_mode_bits.write(1);
-    delay(7); // turn-on transition time (worse case)
+    delay(7); // turn-on transition time (worst case)
     break;
   }
 }

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -388,8 +388,8 @@ bool Adafruit_LIS3DH::enableDRDY(bool enable_drdy, uint8_t int_pin) {
 /*!
  *   @brief  Sets the performance mode for the LIS3DH.
  *
- *   The turn-on time to transition to 12-bit mode (high resolution) is set at 7ms,
- *   or swtch to 10-bit mode (normal) or to 8-bit mode (low power) is 1ms
+ *   The turn-on time to transition to 12-bit mode (high resolution) is set at
+ * 7ms, or swtch to 10-bit mode (normal) or to 8-bit mode (low power) is 1ms
  *
  *   @param  mode
  *          mode - low power, normal, high resolution e.g. LIS3DH_MODE_LOW_POWER

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -222,15 +222,15 @@ void Adafruit_LIS3DH::read(void) {
     lsb_value = 16;
   if (range == LIS3DH_RANGE_16_G)
     lsb_value = 48;
-  
+
   float convert_from_LSB16 = 64000.0;
   if (mode == LIS3DH_MODE_HIGH_RESOLUTION) {
-    lsb_value = lsb_value / 4;  # 1 at 2G, 2 at 4G, 4 at 8G, 12 at 16G
+    lsb_value = lsb_value / 4; // 1 at 2G, 2 at 4G, 4 at 8G, 12 at 16G
     convert_from_LSB16 = LIS3DH_LSB16_TO_KILO_LSB12;
   } else if (mode == LIS3DH_MODE_NORMAL) {
     convert_from_LSB16 = LIS3DH_LSB16_TO_KILO_LSB10;
   } else if (mode == LIS3DH_MODE_LOW_POWER) {
-    lsb_value = lsb_value * 4;  # 16 at 2G, 32 at 4G, 64 at 8G, 192 at 16G
+    lsb_value = lsb_value * 4; // 16 at 2G, 32 at 4G, 64 at 8G, 192 at 16G
     convert_from_LSB16 = LIS3DH_LSB16_TO_KILO_LSB8;
   }
   x_g = lsb_value * ((float)x / convert_from_LSB16);

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -312,6 +312,14 @@
 #define LIS3DH_LSB16_TO_KILO_LSB10                                             \
   64000 ///< Scalar to convert from 16-bit lsb to 10-bit and divide by 1k to
         ///< convert from milli-gs to gs
+#define LIS3DH_LSB16_TO_KILO_LSB12                                             \
+  16000 ///< Scalar to convert from 16-bit lsb to 12-bit and divide by 1k to
+        ///< convert from milli-gs to gs
+#define LIS3DH_LSB16_TO_KILO_LSB8                                              \
+  256000 ///< Scalar to convert from 16-bit lsb to 8-bit and divide by 1k to
+         ///< convert from milli-gs to gs
+
+#define LIS3DH_DEFAULT_SPIFREQ 500000 ///< SPI frequency for LIS3DH
 
 /** A structure to represent scales **/
 typedef enum {
@@ -328,7 +336,17 @@ typedef enum {
   LIS3DH_AXIS_Z = 0x2,
 } lis3dh_axis_t;
 
-/** Used with register 0x2A (LIS3DH_REG_CTRL_REG1) to set bandwidth **/
+/** Operational / performance modes **/
+typedef enum {
+  LIS3DH_MODE_LOW_POWER = 0x0,
+  LIS3DH_MODE_NORMAL = 0x1,
+  LIS3DH_MODE_HIGH_RESOLUTION = 0x2,
+} lis3dh_mode_t;
+
+/*!
+ * @brief  Data rate selection
+ * Used with register 0x2A (LIS3DH_REG_CTRL_REG1) to set bandwidth
+ */
 typedef enum {
   LIS3DH_DATARATE_400_HZ = 0b0111, //  400Hz
   LIS3DH_DATARATE_200_HZ = 0b0110, //  200Hz
@@ -350,8 +368,10 @@ typedef enum {
 class Adafruit_LIS3DH : public Adafruit_Sensor {
 public:
   Adafruit_LIS3DH(TwoWire *Wi = &Wire);
-  Adafruit_LIS3DH(int8_t cspin, SPIClass *theSPI = &SPI);
-  Adafruit_LIS3DH(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin);
+  Adafruit_LIS3DH(int8_t cspin, SPIClass *theSPI = &SPI,
+                  uint32_t frequency = LIS3DH_DEFAULT_SPIFREQ);
+  Adafruit_LIS3DH(int8_t cspin, int8_t mosipin, int8_t misopin, int8_t sckpin,
+                  uint32_t frequency = LIS3DH_DEFAULT_SPIFREQ);
 
   bool begin(uint8_t addr = LIS3DH_DEFAULT_ADDRESS, uint8_t nWAI = 0x33);
 
@@ -361,6 +381,9 @@ public:
 
   void read(void);
   int16_t readADC(uint8_t a);
+
+  lis3dh_mode_t getPerformanceMode(void);
+  void setPerformanceMode(lis3dh_mode_t mode);
 
   void setRange(lis3dh_range_t range);
   lis3dh_range_t getRange(void);
@@ -399,6 +422,7 @@ private:
   int8_t _i2caddr;
 
   int32_t _sensorID;
+  uint32_t _frequency = LIS3DH_DEFAULT_SPIFREQ;
 };
 
 #endif

--- a/examples/acceldemo/acceldemo.ino
+++ b/examples/acceldemo/acceldemo.ino
@@ -17,6 +17,8 @@
 //Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, LIS3DH_MOSI, LIS3DH_MISO, LIS3DH_CLK);
 // hardware SPI
 //Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS);
+// Low Power 5Khz data rate needs faster SPI, and calling setPerformanceMode & setDataRate
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, 2_000_000);
 // I2C
 Adafruit_LIS3DH lis = Adafruit_LIS3DH();
 
@@ -37,6 +39,14 @@ void setup(void) {
   Serial.print("Range = "); Serial.print(2 << lis.getRange());
   Serial.println("G");
 
+  // lis.setPerformanceMode(LIS3DH_MODE_LOW_POWER);
+  Serial.print("Performance mode set to: ");
+  switch (lis.getPerformanceMode()) {
+    case LIS3DH_MODE_NORMAL: Serial.println("Normal 10bit"); break;
+    case LIS3DH_MODE_LOW_POWER: Serial.println("Low Power 8bit"); break;
+    case LIS3DH_MODE_HIGH_RESOLUTION: Serial.println("High Resolution 12bit"); break;
+  }
+
   // lis.setDataRate(LIS3DH_DATARATE_50_HZ);
   Serial.print("Data rate set to: ");
   switch (lis.getDataRate()) {
@@ -50,7 +60,7 @@ void setup(void) {
 
     case LIS3DH_DATARATE_POWERDOWN: Serial.println("Powered Down"); break;
     case LIS3DH_DATARATE_LOWPOWER_5KHZ: Serial.println("5 Khz Low Power"); break;
-    case LIS3DH_DATARATE_LOWPOWER_1K6HZ: Serial.println("16 Khz Low Power"); break;
+    case LIS3DH_DATARATE_LOWPOWER_1K6HZ: Serial.println("1.6 Khz Low Power"); break;
   }
 }
 

--- a/examples/acceldemo/acceldemo.ino
+++ b/examples/acceldemo/acceldemo.ino
@@ -18,7 +18,7 @@
 // hardware SPI
 //Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS);
 // Low Power 5Khz data rate needs faster SPI, and calling setPerformanceMode & setDataRate
-//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, 2_000_000);
+//Adafruit_LIS3DH lis = Adafruit_LIS3DH(LIS3DH_CS, 2000000);
 // I2C
 Adafruit_LIS3DH lis = Adafruit_LIS3DH();
 


### PR DESCRIPTION
This adds the option to switch down to low power mode (8bit), `lis.setPerformanceMode(LIS3DH_MODE_LOW_POWER);` which then gives you the higher frequency values for any that have different data rates between high-resolution/normal and low power modes, i.e. allowing 5.3kHz data rate.
![image](https://github.com/adafruit/Adafruit_LIS3DH/assets/6692083/957d06d1-4088-4818-a55e-8f52bff7093d)

Tested using 2MHz SPI instead of the default 500kHz, via an extra constructor argument added for frequency. I switched through each of the Performance modes (Low Power / Normal / High Resolution) at the fastest data rate (LP_5K = ~5.3/1.3khz - plus a couple of other rates), along with each of the force sensitivity modes (2G/4G/8G/16G) and checked each axis approximated +/-gravity when correctly rotated.
 It was in a loop with 5 prints for each combination (allowing 3 axis measurements and two mistakes) and 3seconds between prints, so I missed one or two out of the many axis measurements, but always got at least one axis measuring approximately gravity per combination

Likely I made a mistake as I'm new to these accelerometers and not the king of bit shifters, but think it's alright. Either way would really appreciate some user testing so please take a look / have a go.
The acceldemo.ino has been updated to print the performance mode (along with the set example commmented out).