### PR TITLE
Add functions to set/get pull-up behavior for LIS3DH from register CTRL_REG0

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -130,6 +130,11 @@ bool Adafruit_LIS3DH::begin(uint8_t i2caddr, uint8_t nWAI) {
     // Serial.println(deviceid, HEX);
     return false;
   }
+
+  Adafruit_BusIO_Register _ctrl0 = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL0, 1);
+  _ctrl0.write(0x10); // Pull-up SDO/SA0 default mode
+
   Adafruit_BusIO_Register _ctrl1 = Adafruit_BusIO_Register(
       i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL1, 1);
   _ctrl1.write(0x07); // enable all axes, normal mode
@@ -507,6 +512,44 @@ lis3dh_dataRate_t Adafruit_LIS3DH::getDataRate(void) {
       Adafruit_BusIO_RegisterBits(&_ctrl1, 4, 4);
 
   return (lis3dh_dataRate_t)data_rate_bits.read();
+}
+
+/*!
+ *  @brief  Sets the pull-up configuration for the LIS3DH
+ *  @param  pullup
+ *          pull-up value (0:is present in hw/1:not present in hw)
+ */
+void Adafruit_LIS3DH::setPullUpConfig(lis3dh_pullup_t pullup) {
+  Adafruit_BusIO_Register _ctrl0 = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL0, 1);
+  Adafruit_BusIO_RegisterBits pullup_config =
+      Adafruit_BusIO_RegisterBits(&_ctrl0, 1, 7);
+
+  switch (pullup) {
+  case LIS3DH_PULLUP_CONNECTED:
+    // Asume Pull-Up is externally connected.
+    pullup_config.write(0);
+    delay(1); // turn-on transition time (worst case)
+    break;
+  case LIS3DH_PULLUP_DISCONECTED:
+    // Asume Pull-Up is externally disconnected, use chip internal instead.
+    pullup_config.write(1);
+    delay(1); // turn-on transition time (worst case)
+    break;
+  }
+}
+
+/*!
+ *  @brief  Gets the pull-up configuration for the LIS3DH
+ *  @return pull-up value (0:is present in hw/1:not present in hw)
+ */
+lis3dh_pullup_t Adafruit_LIS3DH::getPullUpConfig(void) {
+  Adafruit_BusIO_Register _ctrl0 = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL0, 1);
+  Adafruit_BusIO_RegisterBits pullup_config =
+      Adafruit_BusIO_RegisterBits(&_ctrl0, 1, 7);
+
+  return (lis3dh_pullup_t)pullup_config.read();
 }
 
 /*!

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -70,6 +70,14 @@
   0x0E /**< INT_COUNTER register [IC7, IC6, IC5, IC4, IC3, IC2, IC1, IC0] */
 #define LIS3DH_REG_WHOAMI                                                      \
   0x0F /**< Device identification register. [0, 0, 1, 1, 0, 0, 1, 1] */
+
+/*!
+ *  CTRL_REG0
+ *  Disconnect SDO/SA0 pull-up.
+ *   SDO_PU_DISC   Pull-up connected to SDO/SA0 pin. Default value: 0
+ *                 (0: connected; 1: disconnected)
+ */
+#define LIS3DH_REG_CTRL0 0x1E
 /*!
  *  TEMP_CFG_REG
  *  Temperature configuration register.
@@ -321,6 +329,12 @@
 
 #define LIS3DH_DEFAULT_SPIFREQ 500000 ///< SPI frequency for LIS3DH
 
+/** A structure to represent pull-up config **/
+typedef enum {
+  LIS3DH_PULLUP_CONNECTED = 0x0,
+  LIS3DH_PULLUP_DISCONECTED = 0x1
+} lis3dh_pullup_t;
+
 /** A structure to represent scales **/
 typedef enum {
   LIS3DH_RANGE_16_G = 0b11, // +/- 16g
@@ -390,6 +404,9 @@ public:
 
   void setDataRate(lis3dh_dataRate_t dataRate);
   lis3dh_dataRate_t getDataRate(void);
+
+  void setPullUpConfig(lis3dh_pullup_t pullup);
+  lis3dh_pullup_t getPullUpConfig(void);
 
   bool getEvent(sensors_event_t *event);
   void getSensor(sensor_t *sensor);


### PR DESCRIPTION
Sometimes, if your hardware does not consider use external pull-up resistors for I2C you will need to tell the chip to use the internal resistors, for that purpose you can modify register CTRL_REG0 (0x1E) specifically the MSB (1<<7).

This PR adds functions to set/get pull-up status register CTRL_REG0 (0x1E) described in [datasheet ](https://www.st.com/resource/en/datasheet/lis3dh.pdf) page 34.

I Tested on [RAK4631](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK4631/Datasheet) module using base [RAK19007](https://docs.rakwireless.com/product-categories/wisblock/rak19007/datasheet/) and module [RAK1904 ](https://docs.rakwireless.com/Product-Categories/WisBlock/RAK1904/Datasheet)(LIS3DH) via I2C without problems reducing the power consumption due to this misconfiguration.