### PR TITLE
Set interface pointers to NULL in Adafruit_LIS3DH.h

### DIFF
--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -409,11 +409,11 @@ public:
   float z_g; /**< z_g axis value (calculated by selected range) */
 
 private:
-  TwoWire *I2Cinterface;
-  SPIClass *SPIinterface;
+  TwoWire *I2Cinterface = NULL;  ///< Pointer to I2C bus interface
+  SPIClass *SPIinterface = NULL; ///< Pointer to SPI bus interface
 
-  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C bus interface
-  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI bus interface
+  Adafruit_I2CDevice *i2c_dev = NULL; ///< Pointer to I2C device
+  Adafruit_SPIDevice *spi_dev = NULL; ///< Pointer to SPI device
 
   uint8_t _wai;
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit LIS3DH
-version=1.3.0
+version=1.3.1
 author=Adafruit <info@adafruit.com>
 maintainer=Adafruit <info@adafruit.com>
 sentence=Library for the Adafruit LIS3DH Accelerometer.


### PR DESCRIPTION
Initialize I2C and SPI interface pointers to NULL.
