### PR TITLE
Motion detection int

### DIFF
--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -466,3 +466,47 @@ void Adafruit_LIS3DH::getSensor(sensor_t *sensor) {
   sensor->min_value = 0;
   sensor->resolution = 0;
 }
+
+bool Adafruit_LIS3DH::intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t moveType, uint8_t threshold, uint8_t timeDur, bool polarity) {
+  uint8_t dataToWrite = 0;  //Temporary variable
+	bool returnError = true;
+
+  Adafruit_BusIO_Register regToWrite = Adafruit_BusIO_Register(
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == INT_1) ? LIS3DH_REG_INT1CFG : LIS3DH_REG_INT2CFG, 1);
+
+  Adafruit_BusIO_RegisterBits range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 4, 0);
+
+	//Build INT_CFG 0x30 or 0x34
+	//Detect movement or stop
+	if(moveType == 1)	range_bits.write(0x0A);
+	else 							range_bits.write(0x05);
+	
+	//Build INT_THS 0x32 or 0x36
+	regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_INT1THS, 1); 
+  range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 7, 0);
+	range_bits.write(threshold);
+
+	//Build INT_DURATION 0x33 or 0x37
+  regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_INT1DUR, 1); 
+  range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 7, 0);
+	range_bits.write(timeDur);
+
+	//Attach configuration to Interrupt X
+  regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL3, 1);
+	if(interrupt == 1)
+	{
+    range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 1, 7);
+    range_bits.write(1);
+	}
+	else
+	{
+    range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 1, 6);
+    range_bits.write(1);
+	}
+
+  regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL6, 1);
+  range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 2, 0);
+	range_bits.write(0 | (polarity << 1));
+	
+	return returnError;
+}

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -471,13 +471,13 @@ bool Adafruit_LIS3DH::intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t mov
 	bool returnError = true;
 
   Adafruit_BusIO_Register regToWrite = Adafruit_BusIO_Register(
-      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == INT_1) ? LIS3DH_REG_INT1CFG : LIS3DH_REG_INT2CFG, 1);
+      i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == LIS3DH_INT_1) ? LIS3DH_REG_INT1CFG : LIS3DH_REG_INT2CFG, 1);
 
   Adafruit_BusIO_RegisterBits range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 6, 0);
 
 	//Build INT_CFG 0x30 or 0x34
 	//Detect movement or stop
-	if(moveType == DET_MOVE) {
+	if(moveType == LIS3DH_DET_MOVE) {
     range_bits.write(0x0A);
   }
 	else {
@@ -485,17 +485,17 @@ bool Adafruit_LIS3DH::intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t mov
   }
 	
 	//Build INT_THS 0x32 or 0x36
-	regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == INT_1) ? LIS3DH_REG_INT1THS : LIS3DH_REG_INT2THS, 1); 
+	regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == LIS3DH_INT_1) ? LIS3DH_REG_INT1THS : LIS3DH_REG_INT2THS, 1); 
   range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 7, 0);
 	range_bits.write(threshold);
 
 	//Build INT_DURATION 0x33 or 0x37
-  regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == INT_1) ? LIS3DH_REG_INT1DUR : LIS3DH_REG_INT2DUR, 1); 
+  regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, (interrupt == LIS3DH_INT_1) ? LIS3DH_REG_INT1DUR : LIS3DH_REG_INT2DUR, 1); 
   range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 7, 0);
 	range_bits.write(timeDur);
 
 	// Attach configuration to Interrupt X
-	if(interrupt == INT_1)
+	if(interrupt == LIS3DH_INT_1)
 	{
     regToWrite = Adafruit_BusIO_Register(i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL3, 1);
     regToWrite.write(0x40); // enable ia1 on int1 pin

--- a/Adafruit_LIS3DH.cpp
+++ b/Adafruit_LIS3DH.cpp
@@ -513,3 +513,18 @@ bool Adafruit_LIS3DH::intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t mov
 	
 	return returnError;
 }
+
+bool Adafruit_LIS3DH::lowPowerConfig(lis3dh_power_mode_t power_mode) {
+  bool returnError = true;
+  Adafruit_BusIO_Register regToWrite = Adafruit_BusIO_Register(
+    i2c_dev, spi_dev, ADDRBIT8_HIGH_TOREAD, LIS3DH_REG_CTRL1, 1);
+
+  Adafruit_BusIO_RegisterBits range_bits = Adafruit_BusIO_RegisterBits(&regToWrite, 1, 3);
+  range_bits.write(power_mode);
+
+  if (((regToWrite.read() & 0x8) >> 3) != power_mode) {
+    returnError = true;
+  }
+
+  return returnError;
+}

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -222,6 +222,12 @@
  * enable interrupt request.)
  */
 #define LIS3DH_REG_INT1CFG 0x30
+
+/*!
+ *  INT2_CFG
+ */
+#define LIS3DH_REG_INT2CFG 0x34
+
 /*!
  *  INT1_SRC
  *   [0, IA, ZH, ZL, YH, YL, XH, XL]
@@ -343,6 +349,16 @@ typedef enum {
 
 } lis3dh_dataRate_t;
 
+typedef enum {
+	INT_1 = 1,
+	INT_2
+} lis3dh_interrupt_t;
+
+typedef enum {
+	DET_STOP,
+	DET_MOVE,
+} lis3dh_event_t;
+
 /*!
  *  @brief  Class that stores state and functions for interacting with
  *          Adafruit_LIS3DH
@@ -376,6 +392,8 @@ public:
   uint8_t getClick(void);
 
   uint8_t readAndClearInterrupt(void);
+
+  bool intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t moveType, uint8_t threshold, uint8_t timeDur, bool polarity);
 
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -376,18 +376,18 @@ typedef enum {
 } lis3dh_dataRate_t;
 
 typedef enum {
-	INT_1 = 1,
-	INT_2
+	LIS3DH_INT_1 = 1,
+	LIS3DH_INT_2
 } lis3dh_interrupt_t;
 
 typedef enum {
-	DET_STOP,
-	DET_MOVE,
+	LIS3DH_DET_STOP,
+	LIS3DH_DET_MOVE,
 } lis3dh_event_t;
 
 typedef enum {
-  HIGH_RESOLUTION_MODE = 0,
-  LOW_POWER_MODE = 1
+  LIS3DH_HIGH_RESOLUTION_MODE = 0,
+  LIS3DH_LOW_POWER_MODE = 1
 } lis3dh_power_mode_t;
 
 /*!

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -385,6 +385,11 @@ typedef enum {
 	DET_MOVE,
 } lis3dh_event_t;
 
+typedef enum {
+  HIGH_RESOLUTION_MODE = 0,
+  LOW_POWER_MODE = 1
+} lis3dh_power_mode_t;
+
 /*!
  *  @brief  Class that stores state and functions for interacting with
  *          Adafruit_LIS3DH
@@ -420,6 +425,7 @@ public:
   uint8_t readAndClearInterrupt(void);
 
   bool intConfig(lis3dh_interrupt_t interrupt, lis3dh_event_t moveType, uint8_t threshold, uint8_t timeDur, bool polarity);
+  bool lowPowerConfig(lis3dh_power_mode_t power_mode);
 
   int16_t x; /**< x axis value */
   int16_t y; /**< y axis value */

--- a/Adafruit_LIS3DH.h
+++ b/Adafruit_LIS3DH.h
@@ -251,6 +251,32 @@
   0x32 /**< INT1_THS register [0, THS6, THS5, THS4, THS3, THS1, THS0] */
 #define LIS3DH_REG_INT1DUR                                                     \
   0x33 /**< INT1_DURATION [0, D6, D5, D4, D3, D2, D1, D0] */
+
+
+/*!
+ *  INT2_SRC
+ *   [0, IA, ZH, ZL, YH, YL, XH, XL]
+ *    IA  Interrupt active. Default value: 0
+ *        (0: no interrupt has been generated; 1: one or more interrupts have
+ * been generated) ZH  Z high. Default value: 0 (0: no interrupt, 1: Z High
+ * event has occurred) ZL  Z low. Default value: 0 (0: no interrupt; 1: Z Low
+ * event has occurred) YH  Y high. Default value: 0 (0: no interrupt, 1: Y High
+ * event has occurred) YL  Y low. Default value: 0 (0: no interrupt, 1: Y Low
+ * event has occurred) XH  X high. Default value: 0 (0: no interrupt, 1: X High
+ * event has occurred) XL  X low. Default value: 0 (0: no interrupt, 1: X Low
+ * event has occurred)
+ *
+ *    Interrupt 1 source register. Read only register.
+ *    Reading at this address clears INT1_SRC IA bit (and the interrupt signal
+ * on INT 1 pin) and allows the refreshment of data in the INT1_SRC register if
+ * the latched option  was chosen.
+ */
+#define LIS3DH_REG_INT2SRC 0x35
+#define LIS3DH_REG_INT2THS                                                     \
+  0x36 /**< INT1_THS register [0, THS6, THS5, THS4, THS3, THS1, THS0] */
+#define LIS3DH_REG_INT2DUR                                                     \
+  0x37 /**< INT1_DURATION [0, D6, D5, D4, D3, D2, D1, D0] */
+
 /*!
  *  CLICK_CFG
  *   [--, --, ZD, ZS, YD, YS, XD, XS]


### PR DESCRIPTION
## Add interrupt configuration and low-power mode support

### Scope of change

This PR adds two new public methods to `Adafruit_LIS3DH`:

- **`intConfig()`** — configures INT1 or INT2 for motion/stop detection. Sets the interrupt config register (`INT_CFG`), threshold (`INT_THS`), duration (`INT_DUR`), routes the interrupt to the correct pin via CTRL3/CTRL6, and sets the output polarity.
- **`lowPowerConfig()`** — switches the sensor between high-resolution mode and low-power mode via the `LPen` bit in CTRL1.

Supporting additions in `Adafruit_LIS3DH.h`:
- Register definitions for INT2 (`LIS3DH_REG_INT2CFG`, `LIS3DH_REG_INT2SRC`, `LIS3DH_REG_INT2THS`, `LIS3DH_REG_INT2DUR`)
- Three new enums: `lis3dh_interrupt_t` (INT1/INT2), `lis3dh_event_t` (move/stop detection), `lis3dh_power_mode_t` (high-resolution/low-power)

### Known limitations

- `intConfig()` supports only basic movement and position detection patterns (OR combination on X/Y axes). More complex AND combinations or Z-axis specific configs are not exposed.
- When configuring INT2 polarity, `intConfig()` writes to CTRL6 twice (once for routing, once for polarity), which may overwrite the routing bit.
- No example sketch is included in this PR.

### Testing

Tested on hardware with an LIS3DH connected over I2C. Verified interrupt triggering for both movement and stop-detection events on INT1 and INT2 pins.
